### PR TITLE
fix: ensure the folders are correctly marked at startup

### DIFF
--- a/src/fe-handler/folder-mark.ts
+++ b/src/fe-handler/folder-mark.ts
@@ -73,6 +73,7 @@ export default class FolderMark extends FEHandler_Base {
   private initFolderMark() {
     const { vault, metadataCache } = this.app;
     this.markAll();
+    window.setTimeout(this.markAll, 20);
     // #region folder note events setup
     [
       vault.on("folder-note:create", (note: TFile, folder: TFolder) => {


### PR DESCRIPTION
When I open Obsidian, the folders aren’t marked as folders and, to get the right behavior, I had to switch of settings (e.g., update the strategy to another value and come back to my settings). At this point it worked as expected…

After some digging in the code, I found this workaround… I’m not sure it’s the good one… but at least it works.

As I’m absolutely not a web developper, I don’t really know how to package properly a new version of the plugins. So… this PR is my clumsy contribution to the plugin… I can’t contribute to the original owner because I use your fork…

If it can help someone…